### PR TITLE
Ver 0.3 - Minor Fixes and Feature Set

### DIFF
--- a/Arduino-microfox/defs.h
+++ b/Arduino-microfox/defs.h
@@ -57,7 +57,7 @@
 
 /******************************************************
  * Set the text that gets displayed to the user */
-#define SW_REVISION "0.2"
+#define SW_REVISION "0.3"
 
 //#define TRANQUILIZE_WATCHDOG
 
@@ -113,7 +113,7 @@ INVALID_FOX
 
 /******************************************************
  * EEPROM definitions */
-#define EEPROM_INITIALIZED_FLAG 0xAD
+#define EEPROM_INITIALIZED_FLAG 0xAE
 #define EEPROM_UNINITIALIZED 0x00
 
 #define EEPROM_STATION_ID_DEFAULT "FOXBOX"
@@ -129,6 +129,7 @@ INVALID_FOX
 #define EEPROM_INTRA_CYCLE_DELAY_TIME_DEFAULT 0
 #define EEPROM_ID_TIME_INTERVAL_DEFAULT 300
 #define EEPROM_CLOCK_CALIBRATION_DEFAULT 15629
+#define EEPROM_TEMP_CALIBRATION_DEFAULT 147
 #define EEPROM_OVERRIDE_DIP_SW_DEFAULT 0
 #define EEPROM_ENABLE_LEDS_DEFAULT 1
 #define EEPROM_ENABLE_SYNC_DEFAULT 1

--- a/Arduino-microfox/linkbus.cpp
+++ b/Arduino-microfox/linkbus.cpp
@@ -54,6 +54,8 @@ static char g_tempMsgBuff[LINKBUS_MAX_MSG_LENGTH];
 
 /* Local function prototypes */
 BOOL linkbus_start_tx(void);
+BOOL linkbus_send_text(char* text);
+
 
 /* Module global variables */
 static volatile BOOL linkbus_tx_active = FALSE; /* volatile is required to ensure optimizer handles this properly */
@@ -336,25 +338,27 @@ void lb_echo_char(uint8_t c)
 
 BOOL lb_send_string(char* str, BOOL wait)
 {
-	BOOL err;
+	BOOL err = FALSE;
 
 	if(str == NULL)
 	{
 		return( TRUE);
 	}
+	
 	if(strlen(str) > LINKBUS_MAX_TX_MSG_LENGTH)
 	{
 		return( TRUE);
 	}
+	
 	strncpy(g_tempMsgBuff, str, LINKBUS_MAX_TX_MSG_LENGTH);
 
 	if(wait)
 	{
-		while(linkbus_send_text(g_tempMsgBuff))
+		while((err = linkbus_send_text(g_tempMsgBuff)))
 		{
 			;
 		}
-		while(linkbusTxInProgress())
+		while(!err && linkbusTxInProgress())
 		{
 			;
 		}

--- a/Arduino-microfox/linkbus.h
+++ b/Arduino-microfox/linkbus.h
@@ -196,14 +196,6 @@ LinkbusRxBuffer* nextFullRxBuffer(void);
 
 /**
  */
-BOOL linkbus_send_text(char* text);
-
-/**
-*/
-void lb_send_ESP(LBMessageType msgType, char* msg);
-
-/**
- */
 void lb_send_Help(void);
 
 /**


### PR DESCRIPTION
o Fixed a bug that prevented the SPD settings from getting saved to EEPROM.
o Added a temperature calibration value that gets saved to EEPROM.
o Temp calibration gets set using > TEM C <###> command, where ### is tenths of a degree and can be positive or negative value.
o Added comments
o Style and syntax fixes
o Added a time-since-reset seconds counter that could be used to incorporate  delayed start, or shut-off time features.