### PR TITLE
Version 0.11

### DIFF
--- a/Arduino-microfox/defs.h
+++ b/Arduino-microfox/defs.h
@@ -27,6 +27,7 @@
 #define DEFS_H
 
 // #define COMPILE_FOR_ATMELSTUDIO7
+#define HARDWARE_EXTERNAL_DIP_PULLUPS_INSTALLED FALSE
 
 #ifdef COMPILE_FOR_ATMELSTUDIO7
 	#include <avr/io.h>
@@ -52,12 +53,15 @@
 #define OUTPUT 0x1
 #endif
 
-/* #define F_CPU 16000000UL / * gets declared in makefile * / */
+#ifndef INPUT_PULLUP
+#define INPUT_PULLUP 0x3
+#endif
 
+/* #define F_CPU 16000000UL / * gets declared in makefile * / */
 
 /******************************************************
  * Set the text that gets displayed to the user */
-#define SW_REVISION "0.10"
+#define SW_REVISION "0.11"
 
 //#define TRANQUILIZE_WATCHDOG
 
@@ -119,8 +123,6 @@ INVALID_FOX
 
 #define MAX_CODE_SPEED_WPM 20
 #define MIN_CODE_SPEED_WPM 5
-
-#define USE_WATCHDOG
 
 typedef enum
 {
@@ -197,10 +199,9 @@ typedef enum
 #define UINT16_MAX __INT16_MAX__
 #endif
 
-#define ON              1
 #define OFF             0
+#define ON              1
 #define TOGGLE			2
-
 #define UNDETERMINED	3
 
 #define MIN(A,B)    ({ __typeof__(A) __a = (A); __typeof__(B) __b = (B); __a < __b ? __a : __b; })


### PR DESCRIPTION
o Adds optional compile for  external port pin pull-ups. When the HARDWARE_EXTERNAL_DIP_PULLUPS_INSTALLED is set to FALSE (default) the software will turn on the internal port pin pull-ups prior to reading DIP and SYNC pins. Those pins will then be set to outputs (LOW) after all pins have been read, to save power.
o Fixes a bug that prevented the FAC command from resetting the time calibration (CAL) and callsign (ID) settings.
o Reverses the logic of DIP pins so that ON corresponds to "1".
o Turned off the OC0A pin toggle when audio output is active. Only pin 9 is audio output now.
o Minor cleanup and formatting changes