### PR TITLE
Version 0.13

### DIFF
--- a/Arduino-microfox/defs.h
+++ b/Arduino-microfox/defs.h
@@ -61,7 +61,7 @@
 
 /******************************************************
  * Set the text that gets displayed to the user */
-#define SW_REVISION "0.11"
+#define SW_REVISION "0.13"
 
 //#define TRANQUILIZE_WATCHDOG
 
@@ -89,12 +89,12 @@ typedef unsigned char uint8_t;
 #define null 0
 #endif
 
-#define PIN_NANO_LED 13
-#define PIN_NANO_KEY 2
-#define PIN_NANO_SYNC 3
-#define PIN_NANO_DIP_0 4
-#define PIN_NANO_DIP_1 5
-#define PIN_NANO_DIP_2 6
+#define PIN_LED 13
+#define PIN_MORSE_KEY 2
+#define PIN_SYNC 3
+#define PIN_DIP_0 4
+#define PIN_DIP_1 5
+#define PIN_DIP_2 6
 #define PIN_AUDIO_OUT 9
 
 typedef enum {
@@ -141,7 +141,7 @@ typedef enum
 
 /******************************************************
  * EEPROM definitions */
-#define EEPROM_INITIALIZED_FLAG 0xB3
+#define EEPROM_INITIALIZED_FLAG 0xB4
 #define EEPROM_UNINITIALIZED 0x00
 
 #define EEPROM_STATION_ID_DEFAULT "FOXBOX"
@@ -160,24 +160,7 @@ typedef enum
 #define EEPROM_TEMP_CALIBRATION_DEFAULT 147
 #define EEPROM_OVERRIDE_DIP_SW_DEFAULT 0
 #define EEPROM_ENABLE_LEDS_DEFAULT 1
-#define EEPROM_ENABLE_SYNC_DEFAULT 1
 #define EEPROM_ENABLE_STARTTIMER_DEFAULT 1
-
-#define EEPROM_SI5351_CALIBRATION_DEFAULT 0x00
-#define EEPROM_CLK0_OUT_DEFAULT 133000000
-#define EEPROM_CLK1_OUT_DEFAULT 70000000
-#define EEPROM_CLK2_OUT_DEFAULT 10700000
-#define EEPROM_CLK0_ONOFF_DEFAULT OFF
-#define EEPROM_CLK1_ONOFF_DEFAULT OFF
-#define EEPROM_CLK2_ONOFF_DEFAULT OFF
-
-#define EEPROM_BATTERY_EMPTY_MV 3430
-
-/******************************************************
- * General definitions for making the code easier to understand */
-#define         SDA_PIN (1 << PINC4)
-#define         SCL_PIN (1 << PINC5)
-#define         I2C_PINS (SCL_PIN | SDA_PIN)
 
 #ifndef FALSE
    #define FALSE 0
@@ -217,6 +200,7 @@ typedef enum
 #define MAX_TIME 4294967295L
 #define MAX_UINT16 65535
 #define MAX_INT16 32767
+#define MIN_INT16 -32768
 
 /* Periodic TIMER2 interrupt timing definitions */
 #define TIMER2_57HZ 10

--- a/Arduino-microfox/linkbus.h
+++ b/Arduino-microfox/linkbus.h
@@ -96,7 +96,6 @@ typedef enum
 	MESSAGE_FACTORY_RESET = 'F' * 100 + 'A' * 10 + 'C', /* Sets EEPROM back to defaults */
 	MESSAGE_OVERRIDE_DIP = 'D' * 100 + 'I' * 10 + 'P',  /* Override DIP switch settings using this value */
 	MESSAGE_LEDS = 'L' * 100 + 'E' * 10 + 'D',          /* Turn on or off LEDs - accepts 1 or 0 or ON or OFF */
-	MESSAGE_SYNC_ENABLE = 'S' * 100 + 'Y' * 10 + 'N',   /* Enable or disable transmitter syncing */
 	MESSAGE_TEMP = 'T' * 100 + 'E' * 10 + 'M',          /* Temperature  data */
 	MESSAGE_SET_STATION_ID = 'I' * 10 + 'D',            /* Sets amateur radio callsign text */
 	MESSAGE_GO = 'G' * 10 + 'O',                        /* Synchronizes clock */


### PR DESCRIPTION
o Synchronization using the hardware sync pin can now be performed at any time, so long as the sync pin is enabled.
o The sync pin is enabled from power up, but gets disabled after the first transmitter cycle: (5 mins for Classic, 1 min for Sprint)
o Sync is accomplished by pulling the sync pin low for at least one second, and then setting it high. Its internal pull-up resistor is enabled. The pin is effectively debounced in software.
o Removed the SYN serial command, so there is now no way to disable sync using a command.
o Fixed a few minor bugs in the TEM command.
o Some refactoring of macro names