### PR TITLE
Ver 0.17

### DIFF
--- a/Arduino-microfox/Arduino-microfox.ino
+++ b/Arduino-microfox/Arduino-microfox.ino
@@ -178,7 +178,7 @@ void doSynchronization(void);
 {
 	while(initializeEEPROMVars())
 	{
-		;                                                                                                                                                                                                                                                                                                                                                                           /* Initialize variables stored in EEPROM */
+		;                                                                                                                                                                                                                                                                                                                                                                                           /* Initialize variables stored in EEPROM */
 	}
 
 	setUpTemp();
@@ -329,7 +329,7 @@ void doSynchronization(void);
 		g_number_of_foxes = 1;
 		g_pattern_codespeed = 8;
 		g_id_interval = 600;
-		g_startclock_interval = 300;
+		g_startclock_interval = (g_fox == SPECTATOR) ? 120 : 300;
 	}
 	else if(((g_fox >= FOX_1) && (g_fox <= FOX_5)) || (g_fox == FOX_DEMO))
 	{
@@ -907,7 +907,7 @@ ISR(TIMER1_COMPA_vect)              /*timer1 interrupt 1Hz */
 		}
 	}
 
-	if((g_seconds_since_sync + 11) % g_startclock_interval <= 10)
+	if(g_enable_start_timer && ((g_seconds_since_sync + 11) % g_startclock_interval <= 10))
 	{
 		g_lastSeconds = (uint8_t)((g_seconds_since_sync + 11) % g_startclock_interval);
 	}

--- a/Arduino-microfox/defs.h
+++ b/Arduino-microfox/defs.h
@@ -70,7 +70,7 @@
 
 /******************************************************
  * Set the text that gets displayed to the user */
-#define SW_REVISION "0.16"
+#define SW_REVISION "0.17"
 
 //#define TRANQUILIZE_WATCHDOG
 


### PR DESCRIPTION
Fixes these two minor bugs:
o When start tones were turned off, the audio tone output would be silenced during the time that the start tone sequence would have played. The key output pin still functioned as intended.
o Start tones had a 5-minute interval if the transmitter were set to function as a Sprint spectator beacon, instead of a more appropriate 2-minute interval.