### PR TITLE
Version 0.18

### DIFF
--- a/Arduino-microfox/defs.h
+++ b/Arduino-microfox/defs.h
@@ -70,7 +70,7 @@
 
 /******************************************************
  * Set the text that gets displayed to the user */
-#define SW_REVISION "0.17"
+#define SW_REVISION "0.18"
 
 //#define TRANQUILIZE_WATCHDOG
 
@@ -111,7 +111,6 @@ typedef unsigned char uint8_t;
 #define PIN_UNUSED_12 12
 #define PIN_LED 13
 
-
 typedef enum {
 BEACON = 0,
 FOX_1,
@@ -133,6 +132,8 @@ SPRINT_F3,
 SPRINT_F4,
 SPRINT_F5,
 SPRINT_DEMO,
+NO_CODE_START_TONES_2M,
+NO_CODE_START_TONES_5M,
 INVALID_FOX
 } FoxType;
 


### PR DESCRIPTION
o Modes were added to allow the start tones to play without Morse code being sent between starting intervals. Both 2-minute and 5-minute silent starts are supported. The transmitter is not keyed in these modes.
o Setting the DIP value in software applies the new DIP value immediately without a reset.
o The LED (if enabled) is disabled after the first cycle completes, to save power.
o Unused watchdog timer functionality was deleted.