### PR TITLE
Ver 0.22

### DIFF
--- a/Arduino-microfox/defs.h
+++ b/Arduino-microfox/defs.h
@@ -70,7 +70,7 @@
 
 /******************************************************
  * Set the text that gets displayed to the user */
-#define SW_REVISION "0.21"
+#define SW_REVISION "0.22"
 
 //#define TRANQUILIZE_WATCHDOG
 
@@ -157,7 +157,7 @@ typedef enum
 
 /******************************************************
  * EEPROM definitions */
-#define EEPROM_INITIALIZED_FLAG 0xB5
+#define EEPROM_INITIALIZED_FLAG 0xB7 /* Never set to 0xFF */
 #define EEPROM_UNINITIALIZED 0x00
 
 #define EEPROM_STATION_ID_DEFAULT "FOXBOX"


### PR DESCRIPTION
o Fixes a bug that allowed CAL and ID values to be overwritten after a software installation applies new EEPROM settings.
o Fixes a bug that allowed the LED to be stuck in the ON state after turning off LEDs with the LED command.